### PR TITLE
Added support for content-editable containers (divs).

### DIFF
--- a/jquery.caret.js
+++ b/jquery.caret.js
@@ -27,6 +27,31 @@
       var end   = element.selectionEnd;
 
       element.value = element.value.substr(0, start) + text + element.value.substr(end, element.value.length);
+    } else if (document.getSelection() && document.getSelection().anchorNode) {
+      // Selection of contenteditable elements (divs)
+      element.focus();
+      anchorNode = document.getSelection().anchorNode;
+      focusNode = document.getSelection().focusNode;
+
+      // Ignore selection over multiple nodes (TODO?)
+      if (! $(anchorNode).closest(element).length || anchorNode != focusNode) {
+        return false;
+      }
+
+      origContent = anchorNode.textContent;
+      anchorOffset = document.getSelection().anchorOffset || 0;
+      focusOffset = document.getSelection().focusOffset || 0;
+
+      if (anchorOffset == focusOffset) {
+        // No selection: insert at caret position
+        anchorNode.textContent = [origContent.slice(0, anchorOffset), text, origContent.slice(anchorOffset)].join('');
+      } else {
+        // Selection within the same node: replace selection
+        anchorNode.textContent = [origContent.slice(0, anchorOffset), text, origContent.slice(focusOffset)].join('');
+      }
+
+      // Don't need to position caret
+      return this;
     }
     
     if (start) {


### PR DESCRIPTION
I recently needed to use this on a contenteditable div. I realised divs don't respond to `document.selection` but only to `document.getSelection()`, so that's how I implemented it.

The **insertion** occures either at _caret position_ or if a _single pair of nodes_ are selected (multiple node selection is currently ignored because frankly I didn't need it + it comes with some nasty DOM changes).

Anyway, hope it helps someone.
