### PR TITLE
Fix for selectionStart == 0

### DIFF
--- a/jquery.caret.js
+++ b/jquery.caret.js
@@ -59,7 +59,7 @@
       return this;
     }
     
-    if (start) {
+    if (typeof start !== 'undefined') {
       setCaretTo(element, start + text.length);
     } else {
       element.value = text + element.value;

--- a/jquery_caret_test.html
+++ b/jquery_caret_test.html
@@ -46,6 +46,7 @@
     }},
     
     testInsertAtCaret: function() { with(this) {
+      assertEqual('hello', $('#test_input').val('').setCaretPosition(0).insertAtCaret('hello').val());
       assertEqual('hello', $('#test_input').val('helo').setCaretPosition(2).insertAtCaret('l').val());
       assertEqual('why hello', $('#test_input').val('hello').setCaretPosition(0).insertAtCaret('why ').val());
     }},
@@ -61,6 +62,7 @@
     
     testTextareaInsertAtCaret: function() { with(this){
       $('<textarea/>').attr('id', 'test_textarea').appendTo(document.body).focus().css({'position': 'absolute', 'top': '-10100px'})
+      assertEqual('this is a test', $('#test_textarea').val('').setCaretPosition(0).insertAtCaret('this is a test').val());
       assertEqual('this is a test', $('#test_textarea').val('is a test').setCaretPosition(0).insertAtCaret('this ').val());
       assertEqual('this is a test', $('#test_textarea').val('this  test').setCaretPosition(5).insertAtCaret('is a').val());
     }}


### PR DESCRIPTION
Hi,
This is a fix related to @schulzch fix about selectionStart == 0. Also I added two tests when doing insertAtCaret into an empty textarea.

Before fixing this issue I  tested on OSX 10.9 Chrome 31, FIrefox 25 and Safari 7.0, as you can see in the image tests were failing: [with errors](https://www.dropbox.com/s/6u0xkb6lmj3rgzd/jquery.caret_test_errors.png)

After the fix: [no errors](https://www.dropbox.com/s/d36iv06s4lyj25v/jquery.caret_test_no_errors.png)

Thanks for your nice plugin :)
